### PR TITLE
Don't depend on LALInference

### DIFF
--- a/bin/gbmscan_lvalert
+++ b/bin/gbmscan_lvalert
@@ -58,7 +58,7 @@ __author__ = "Leo Singer <leo.singer@ligo.org>"
 #
 
 from optparse import Option, OptionParser
-from lalinference.bayestar import command
+# from lalinference.bayestar import command
 import logging
 import sys
 import json
@@ -67,7 +67,7 @@ logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger('GBUTS')
 
 parser = OptionParser(
-    formatter=command.NewlinePreservingHelpFormatter(),
+    # formatter=command.NewlinePreservingHelpFormatter(),
     description=__doc__,
     usage="%prog [options] [GRACEID SKYMAP.fits[.gz]]"
 )


### PR DESCRIPTION
At the expense of a slightly less readable `--help` message.
